### PR TITLE
Feature/document view plus some additions to allow for better organisation admin and momofin admin use on the frontend

### DIFF
--- a/src/main/java/ppl/momofin/momofinbackend/controller/MomofinAdminController.java
+++ b/src/main/java/ppl/momofin/momofinbackend/controller/MomofinAdminController.java
@@ -7,6 +7,8 @@ import ppl.momofin.momofinbackend.error.InvalidOrganizationException;
 import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;
 import ppl.momofin.momofinbackend.error.UserAlreadyExistsException;
 import ppl.momofin.momofinbackend.model.Organization;
+import ppl.momofin.momofinbackend.model.User;
+import ppl.momofin.momofinbackend.response.FetchAllUserResponse;
 import ppl.momofin.momofinbackend.service.OrganizationService;
 import ppl.momofin.momofinbackend.response.OrganizationResponse;
 import ppl.momofin.momofinbackend.service.UserService;
@@ -32,6 +34,15 @@ public class MomofinAdminController {
         List<Organization> organizations = organizationService.getAllOrganizations();
         List<OrganizationResponse> responses = organizations.stream()
                 .map(OrganizationResponse::fromOrganization)
+                .toList();
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<List<FetchAllUserResponse>> getAllUsers() {
+        List<User> users = userService.fetchAllUsers();
+        List<FetchAllUserResponse> responses = users.stream()
+                .map(FetchAllUserResponse::fromUser)
                 .toList();
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
+++ b/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
@@ -20,6 +20,12 @@ public class OrganizationController {
         this.organizationService = organizationService;
     }
 
+    @GetMapping("/{orgId}")
+    public ResponseEntity<Organization> getOrganization(@PathVariable Long orgId) {
+        Organization organization = organizationService.findOrganizationById(orgId);
+        return ResponseEntity.ok(organization);
+    }
+
     @PutMapping("/{orgId}")
     public ResponseEntity<Organization> updateOrganization(@PathVariable Long orgId, @RequestBody Organization organizationDetails) {
         Organization updatedOrganization = organizationService.updateOrganization(orgId, organizationDetails.getName(), organizationDetails.getDescription());

--- a/src/main/java/ppl/momofin/momofinbackend/error/OrganizationNotFoundException.java
+++ b/src/main/java/ppl/momofin/momofinbackend/error/OrganizationNotFoundException.java
@@ -4,4 +4,8 @@ public class OrganizationNotFoundException extends RuntimeException{
     public OrganizationNotFoundException(String organizationName) {
         super("The organization "+ organizationName + " is not registered to our database");
     }
+
+    public OrganizationNotFoundException() {
+        super("Organization not found");
+    }
 }

--- a/src/main/java/ppl/momofin/momofinbackend/repository/DocumentRepository.java
+++ b/src/main/java/ppl/momofin/momofinbackend/repository/DocumentRepository.java
@@ -11,5 +11,6 @@ import java.util.Optional;
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
     Optional<Document> findByHashString(String hashString);
+    Optional<Document> findByDocumentId(Long documentId);
     List<Document> findAllByOwner(User user);
 }

--- a/src/main/java/ppl/momofin/momofinbackend/response/DocumentViewUrlResponse.java
+++ b/src/main/java/ppl/momofin/momofinbackend/response/DocumentViewUrlResponse.java
@@ -1,0 +1,14 @@
+package ppl.momofin.momofinbackend.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentViewUrlResponse implements Response{
+    private String url;
+}

--- a/src/main/java/ppl/momofin/momofinbackend/response/FetchAllUserResponse.java
+++ b/src/main/java/ppl/momofin/momofinbackend/response/FetchAllUserResponse.java
@@ -1,0 +1,29 @@
+package ppl.momofin.momofinbackend.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ppl.momofin.momofinbackend.model.User;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FetchAllUserResponse {
+    private Long userId;
+    private String username;
+    private String name;
+    private String email;
+    private String organization;
+
+    public static FetchAllUserResponse fromUser(User user) {
+        return new FetchAllUserResponse(
+                user.getUserId(),
+                user.getUsername(),
+                user.getName(),
+                user.getEmail(),
+                user.getOrganization().getName()
+        );
+    }
+}

--- a/src/main/java/ppl/momofin/momofinbackend/security/JwtUtil.java
+++ b/src/main/java/ppl/momofin/momofinbackend/security/JwtUtil.java
@@ -22,6 +22,8 @@ public class JwtUtil {
         Map<String, Object> claims = new HashMap<>();
         claims.put("roles", new ArrayList<>(user.getRoles()));  // Convert Set to List
         claims.put("organizationId", user.getOrganization().getOrganizationId());
+        claims.put("organizationName", user.getOrganization().getName());
+        claims.put("userId", user.getUserId());
         claims.put("isOrganizationAdmin", user.isOrganizationAdmin());
         claims.put("isMomofinAdmin", user.isMomofinAdmin());
         return createToken(claims, user.getUsername());
@@ -53,13 +55,17 @@ public class JwtUtil {
         return extractClaim(token, claims -> claims.get("organizationId", Long.class));
     }
 
+    public String extractOrganizationName(String token) {
+        return extractClaim(token, claims -> claims.get("organizationName", String.class));
+    }
+
     public Boolean extractIsOrganizationAdmin(String token) {
         return extractClaim(token, claims -> claims.get("isOrganizationAdmin", Boolean.class));
     }
 
     private String createToken(Map<String, Object> claims, String subject) {
         return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME * 1000))
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY).compact();
     }
 

--- a/src/main/java/ppl/momofin/momofinbackend/service/CDNService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/CDNService.java
@@ -8,4 +8,5 @@ import java.io.IOException;
 
 public interface CDNService {
     Document uploadFile(MultipartFile file, User user, String hashString) throws IOException;
+    String getViewableUrl(String fileName, String username, String organizationName) throws IOException;
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/DocumentService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/DocumentService.java
@@ -13,4 +13,5 @@ public interface DocumentService {
     String submitDocument(MultipartFile file, String username) throws IOException, NoSuchAlgorithmException, InvalidKeyException;
     Document verifyDocument(MultipartFile file, String username) throws IOException, NoSuchAlgorithmException, InvalidKeyException;
     List<Document> findAllDocumentsByOwner(User user);
+    String getViewableUrl(Long documentId, String username, String organizationName) throws IOException;
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/DocumentServiceImpl.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/DocumentServiceImpl.java
@@ -108,4 +108,15 @@ public class DocumentServiceImpl implements DocumentService {
         }
         return documentRepository.findAllByOwner(user);
     }
+
+    @Override
+    public String getViewableUrl(Long documentId, String username, String organizationName) throws IOException {
+        Optional<Document> optionalDocument = documentRepository.findByDocumentId(documentId);
+
+        if (optionalDocument.isEmpty()) throw new IllegalArgumentException("Document with id " + documentId + " does not exist");
+
+        Document document = optionalDocument.get();
+        String filename = document.getName();
+        return cdnService.getViewableUrl(filename, username, organizationName);
+    }
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/GoogleCloudStorageCDNService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/GoogleCloudStorageCDNService.java
@@ -18,7 +18,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/ppl/momofin/momofinbackend/service/GoogleCloudStorageCDNService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/GoogleCloudStorageCDNService.java
@@ -1,10 +1,7 @@
 package ppl.momofin.momofinbackend.service;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -15,11 +12,15 @@ import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.repository.DocumentRepository;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class GoogleCloudStorageCDNService implements CDNService {
@@ -77,7 +78,7 @@ public class GoogleCloudStorageCDNService implements CDNService {
     @Override
     public Document uploadFile(MultipartFile file, User user, String hashString) throws IOException {
         String fileName = StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
-        String folderName = user.getOrganization().getName() +"/" + user.getName();
+        String folderName = user.getOrganization().getName() +"/" + user.getUsername();
         BlobId blobId = BlobId.of(bucketName, folderName + "/" + fileName);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
                 .setContentType("application/pdf")
@@ -89,5 +90,20 @@ public class GoogleCloudStorageCDNService implements CDNService {
         document.setName(fileName);
         document.setOwner(user);
         return documentRepository.save(document);
+    }
+
+    @Override
+    public String getViewableUrl(String fileName, String username, String organizationName) throws IOException {
+        String folderName = organizationName + "/" + username;
+        BlobId blobId = BlobId.of(bucketName, folderName + "/" + fileName);
+        Blob blob = storage.get(blobId);
+
+        if (blob == null) {
+            throw new FileNotFoundException("File not found: " + fileName);
+        }
+
+        // Generate a signed URL that expires in 1 hour
+        URL signedUrl = blob.signUrl(1, TimeUnit.HOURS);
+        return signedUrl.toString();
     }
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
@@ -73,9 +73,9 @@ public class OrganizationService {
         return UserDTO.fromUser(savedUser);
     }
 
-    private Organization findOrganizationById(Long orgId) {
+    public Organization findOrganizationById(Long orgId) {
         return organizationRepository.findById(orgId)
-                .orElseThrow(() -> new RuntimeException("Organization not found"));
+                .orElseThrow(OrganizationNotFoundException::new);
     }
 
     private User findUserById(Long userId) {

--- a/src/test/java/ppl/momofin/momofinbackend/controller/DocumentVerificationControllerTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/controller/DocumentVerificationControllerTest.java
@@ -19,7 +19,6 @@ import ppl.momofin.momofinbackend.service.DocumentService;
 import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.service.UserService;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 

--- a/src/test/java/ppl/momofin/momofinbackend/controller/DocumentVerificationControllerTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/controller/DocumentVerificationControllerTest.java
@@ -18,6 +18,9 @@ import ppl.momofin.momofinbackend.security.JwtUtil;
 import ppl.momofin.momofinbackend.service.DocumentService;
 import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.service.UserService;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.List;
 
 import java.util.Collections;
@@ -167,5 +170,44 @@ class DocumentVerificationControllerTest {
                 .andExpect(status().isForbidden());
 
         verifyNoInteractions(documentService);
+    }
+
+    @Test
+    void getViewableUrl_Success_ReturnsOkResponse() throws Exception {
+        // Arrange
+        Long documentId = 1L;
+        String organizationName = "testorg";
+        String viewableUrl = "https://cdn.example.com/document-url";
+
+        when(jwtUtil.extractOrganizationName("validToken")).thenReturn(organizationName);
+        when(documentService.getViewableUrl(documentId, TEST_USERNAME, organizationName)).thenReturn(viewableUrl);
+
+        mockMvc.perform(get("/doc/view/1")
+                .header("Authorization", VALID_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value(viewableUrl));
+
+        verify(jwtUtil, times(2)).extractUsername("validToken");
+        verify(jwtUtil, times(1)).extractOrganizationName("validToken");
+        verify(documentService, times(1)).getViewableUrl(documentId, TEST_USERNAME, organizationName);
+    }
+
+    @Test
+    void getViewableUrl_DocumentServiceThrowsIOException_ReturnsBadRequest() throws Exception {
+        // Arrange
+        Long documentId = 1L;
+        String organizationName = "testorg";
+
+        when(jwtUtil.extractOrganizationName("validToken")).thenReturn(organizationName);
+        when(documentService.getViewableUrl(documentId, TEST_USERNAME, organizationName)).thenThrow(new IOException("File not found: test.txt"));
+
+        mockMvc.perform(get("/doc/view/1")
+                        .header("Authorization", VALID_TOKEN))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorMessage").value("Error retrieving document: File not found: test.txt"));
+
+        verify(jwtUtil, times(2)).extractUsername("validToken");
+        verify(jwtUtil, times(1)).extractOrganizationName("validToken");
+        verify(documentService, times(1)).getViewableUrl(documentId, TEST_USERNAME, organizationName);
     }
 }

--- a/src/test/java/ppl/momofin/momofinbackend/controller/MomofinAdminControllerTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/controller/MomofinAdminControllerTest.java
@@ -13,12 +13,16 @@ import ppl.momofin.momofinbackend.error.UserAlreadyExistsException;
 import ppl.momofin.momofinbackend.model.Organization;
 import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.request.AddOrganizationRequest;
+import ppl.momofin.momofinbackend.response.FetchAllUserResponse;
 import ppl.momofin.momofinbackend.service.OrganizationService;
 import ppl.momofin.momofinbackend.response.OrganizationResponse;
 import ppl.momofin.momofinbackend.service.UserService;
+import ppl.momofin.momofinbackend.utility.Roles;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -226,5 +230,42 @@ class MomofinAdminControllerTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCode().value());
         assertNotNull(response.getBody());
         assertEquals("An unexpected error occurred", response.getBody().getErrorMessage());
+    }
+
+    @Test
+    void fetchAllUsersTest() {
+        List<User> users = getUsers();
+
+        when(userService.fetchAllUsers()).thenReturn(users);
+
+        ResponseEntity<List<FetchAllUserResponse>> response = momofinAdminController.getAllUsers();
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
+        for (int i = 0; i<5; i++) {
+            assertEquals(users.get(i).getUserId(), Objects.requireNonNull(response.getBody()).get(i).getUserId());
+            assertEquals(users.get(i).getOrganization().getName(), Objects.requireNonNull(response.getBody()).get(i).getOrganization());
+            assertEquals(users.get(i).getUsername(), Objects.requireNonNull(response.getBody()).get(i).getUsername());
+            assertEquals(users.get(i).getName(), Objects.requireNonNull(response.getBody()).get(i).getName());
+            assertEquals(users.get(i).getEmail(), Objects.requireNonNull(response.getBody()).get(i).getEmail());
+        }
+    }
+
+    private static List<User> getUsers() {
+        Organization momofin = new Organization("Momofin");
+        User user1 = new User(momofin, "Momofin Financial Samuel","Samuel", "samuel@gmail.com", "encodedMy#Money9078", "Finance Manager");
+        User user2 = new User(momofin, "Momofin CEO Darrel", "Darrel Hoei", "darellhoei@gmail.com", "encodedHisPassword#6768", "Co-Founder", true);
+        User user3 = new User(momofin, "Momofin Admin Alex", "Alex", "alex@outlook.com", "encodedAlex&Password0959", "Admin", new Roles(true,true));
+
+        List<User> users = new ArrayList<User>();
+        users.add(user1);
+        users.add(user2);
+        users.add(user3);
+
+        Organization otherOrganization = new Organization("Dondozo");
+        User user4 = new User(otherOrganization, "Dondozo Intern Ron", "Ron", "temp-intern@yahoo.com", "encoded123456", "Intern");
+        User user5 = new User(otherOrganization, "Dondozo Commander Tatsugiri","Tatsugiri", "commander@email.com", "encodedToxic%Mouth", "Commander", true);
+
+        users.add(user4);
+        users.add(user5);
+        return users;
     }
 }

--- a/src/test/java/ppl/momofin/momofinbackend/controller/OrganizationControllerTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/controller/OrganizationControllerTest.java
@@ -16,6 +16,7 @@ import ppl.momofin.momofinbackend.service.OrganizationService;
 import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -81,5 +82,17 @@ class OrganizationControllerTest {
                         .content("{\"username\":\"updateduser\",\"name\":\"Updated User\",\"email\":\"updated@example.com\",\"position\":\"Senior Developer\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("testuser"));
+    }
+
+    @Test
+    void getOrganizationTest() throws Exception {
+        when(organizationService.findOrganizationById(1L)).thenReturn(testOrg);
+
+        mockMvc.perform(get("/api/organizations/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Test Org"))
+                .andExpect(jsonPath("$.description").value("Test Description"));
+
+        verify(organizationService).findOrganizationById(1L);
     }
 }

--- a/src/test/java/ppl/momofin/momofinbackend/model/UserTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/model/UserTest.java
@@ -116,8 +116,8 @@ class UserTest {
         String username = "Position_Name or something";
         User user = new User();
 
-        user.setName(username);
-        assertEquals(username, user.getName());
+        user.setUsername(username);
+        assertEquals(username, user.getUsername());
     }
 
 

--- a/src/test/java/ppl/momofin/momofinbackend/response/DocumentViewUrlResponseTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/response/DocumentViewUrlResponseTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DocumentViewUrlResponseTest {
+class DocumentViewUrlResponseTest {
     @Test
     void testDocumentViewUrlResponseConstructorEmpty() {
         DocumentViewUrlResponse documentViewUrlResponse = new DocumentViewUrlResponse();

--- a/src/test/java/ppl/momofin/momofinbackend/response/DocumentViewUrlResponseTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/response/DocumentViewUrlResponseTest.java
@@ -1,0 +1,33 @@
+package ppl.momofin.momofinbackend.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DocumentViewUrlResponseTest {
+    @Test
+    void testDocumentViewUrlResponseConstructorEmpty() {
+        DocumentViewUrlResponse documentViewUrlResponse = new DocumentViewUrlResponse();
+
+        assertNotNull(documentViewUrlResponse);
+        assertNull(documentViewUrlResponse.getUrl());
+    }
+
+    @Test
+    void testDocumentViewUrlResponseConstructor() {
+        String viewableUrl = "https://cdn.example.com/document-url";
+        DocumentViewUrlResponse documentViewUrlResponse = new DocumentViewUrlResponse(viewableUrl);
+
+        assertEquals(viewableUrl, documentViewUrlResponse.getUrl());
+    }
+
+    @Test
+    void testGetSetUrl() {
+        String viewableUrl = "https://cdn.example.com/document-url";
+        DocumentViewUrlResponse documentViewUrlResponse = new DocumentViewUrlResponse();
+
+        documentViewUrlResponse.setUrl(viewableUrl);
+        assertEquals(viewableUrl, documentViewUrlResponse.getUrl());
+    }
+}

--- a/src/test/java/ppl/momofin/momofinbackend/response/FetchAllUserResponseTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/response/FetchAllUserResponseTest.java
@@ -1,0 +1,108 @@
+package ppl.momofin.momofinbackend.response;
+
+import org.junit.jupiter.api.Test;
+import ppl.momofin.momofinbackend.model.Organization;
+import ppl.momofin.momofinbackend.model.User;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FetchAllUserResponseTest {
+    @Test
+    void testFetchAllUserResponseConstructorEmpty() {
+        FetchAllUserResponse userResponse = new FetchAllUserResponse();
+
+        assertNotNull(userResponse);
+        assertNull(userResponse.getUserId());
+        assertNull(userResponse.getOrganization());
+        assertNull(userResponse.getUsername());
+        assertNull(userResponse.getName());
+        assertNull(userResponse.getEmail());
+    }
+
+    @Test
+    void testFetchAllUserResponseConstructor() {
+        Long userId = 1L;
+        String organization = "testOrganization";
+        String username = "Manager_Test";
+        String name = "testname";
+        String email = "test@example.com";
+
+        FetchAllUserResponse userResponse = new FetchAllUserResponse(userId, username, name, email, organization);
+
+        assertNotNull(userResponse);
+        assertEquals(userId, userResponse.getUserId());
+        assertEquals(organization, userResponse.getOrganization());
+        assertEquals(username, userResponse.getUsername());
+        assertEquals(name, userResponse.getName());
+        assertEquals(email, userResponse.getEmail());
+    }
+
+    @Test
+    void testGetSetUserId() {
+        Long userId = 1L;
+        FetchAllUserResponse userResponse = new FetchAllUserResponse();
+
+        userResponse.setUserId(userId);
+        assertEquals(userId, userResponse.getUserId());
+    }
+
+    @Test
+    void  testGetSetOrganization() {
+        String organization = "testOrganization";
+        FetchAllUserResponse userResponse = new FetchAllUserResponse();
+
+        userResponse.setOrganization(organization);
+        assertEquals(organization, userResponse.getOrganization());
+    }
+    @Test
+    void testGetSetUsername() {
+        String username = "testUser";
+        FetchAllUserResponse userResponse = new FetchAllUserResponse();
+
+        userResponse.setUsername(username);
+        assertEquals(username, userResponse.getUsername());
+    }
+
+
+    @Test
+    void testGetSetName() {
+        String name = "testName";
+        FetchAllUserResponse userResponse = new FetchAllUserResponse();
+
+        userResponse.setName(name);
+        assertEquals(name, userResponse.getName());
+    }
+
+    @Test
+    void testGetSetEmail() {
+        String email = "test@email.com";
+        FetchAllUserResponse userResponse = new FetchAllUserResponse();
+
+        userResponse.setEmail(email);
+        assertEquals(email, userResponse.getEmail());
+    }
+
+    @Test
+    void testFromUser() {
+        String organizationName = "test org name";
+        Organization organization = new Organization();
+        organization.setName(organizationName);
+        String username = "Manager Test";
+        String name = "testname";
+        String email = "test@example.com";
+        String password = "testpassword";
+        String position = "Manager";
+
+        User user = new User(organization, username, name, email, password, position);
+
+        FetchAllUserResponse userResponse = FetchAllUserResponse.fromUser(user);
+
+        assertNotNull(userResponse);
+        assertNull(userResponse.getUserId());
+        assertEquals(organizationName, userResponse.getOrganization());
+        assertEquals(username, userResponse.getUsername());
+        assertEquals(name, userResponse.getName());
+        assertEquals(email, userResponse.getEmail());
+    }
+}

--- a/src/test/java/ppl/momofin/momofinbackend/response/FetchAllUserResponseTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/response/FetchAllUserResponseTest.java
@@ -7,7 +7,7 @@ import ppl.momofin.momofinbackend.model.User;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class FetchAllUserResponseTest {
+class FetchAllUserResponseTest {
     @Test
     void testFetchAllUserResponseConstructorEmpty() {
         FetchAllUserResponse userResponse = new FetchAllUserResponse();

--- a/src/test/java/ppl/momofin/momofinbackend/service/GoogleCloudStorageCDNServiceTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/service/GoogleCloudStorageCDNServiceTest.java
@@ -22,6 +22,7 @@ import ppl.momofin.momofinbackend.repository.DocumentRepository;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
@@ -111,7 +112,8 @@ class GoogleCloudStorageCDNServiceTest {
         BlobId blobId = BlobId.of(bucketName, folderPath);
 
         when(mockStorage.get(blobId)).thenReturn(blob);
-        URL signedUrl = new URL("https://signed-url.com");
+        URI signedUri = URI.create("https://signed-url.com");
+        URL signedUrl = signedUri.toURL();
         when(blob.signUrl(1, TimeUnit.HOURS)).thenReturn(signedUrl);
 
         // Act

--- a/src/test/java/ppl/momofin/momofinbackend/service/OrganizationServiceTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/service/OrganizationServiceTest.java
@@ -258,4 +258,17 @@ class OrganizationServiceTest {
         assertThrows(InvalidOrganizationException.class,
                 () -> organizationService.createOrganization(null, "Description"));
     }
+
+    @Test
+    void findOrganization_success() {
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(testOrg));
+        Organization organization = organizationService.findOrganizationById(1L);
+        assertEquals(testOrg, organization);
+    }
+    @Test
+    void findOrganization_shouldThrowException_whenOrganizationNotFound() {
+        when(organizationRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(OrganizationNotFoundException.class,
+                () -> organizationService.findOrganizationById(1L));
+    }
 }

--- a/src/test/java/ppl/momofin/momofinbackend/utility/JwtUtilTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/utility/JwtUtilTest.java
@@ -117,6 +117,12 @@ class JwtUtilTest {
     }
 
     @Test
+    void extractOrganizationName_WithValidToken_ShouldReturnUsername() {
+        String token = jwtUtil.generateToken(testUser);
+        assertEquals(testUser.getOrganization().getName(), jwtUtil.extractOrganizationName(token));
+    }
+
+    @Test
     void extractOrganizationId_WithValidToken_ShouldReturnOrganizationId() {
         String token = jwtUtil.generateToken(testUser);
         assertEquals(testUser.getOrganization().getOrganizationId(), jwtUtil.extractOrganizationId(token));


### PR DESCRIPTION
This pull request mainly contains implementation to view documents on the frontend, but it also has some other tweaks/additions that help integrate the backend with the frontend better, such as being able to fetch the admin's organization and adding an endpoint to fetch all users as a momofin admin