### PR TITLE
Feature/org admin safe deletion branch merge to dev

### DIFF
--- a/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
+++ b/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
@@ -1,23 +1,39 @@
 package ppl.momofin.momofinbackend.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import ppl.momofin.momofinbackend.dto.UserDTO;
+import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;
+import ppl.momofin.momofinbackend.error.UserDeletionException;
 import ppl.momofin.momofinbackend.model.Organization;
+import ppl.momofin.momofinbackend.model.User;
+import ppl.momofin.momofinbackend.response.ErrorResponse;
+import ppl.momofin.momofinbackend.response.Response;
+import ppl.momofin.momofinbackend.security.JwtUtil;
 import ppl.momofin.momofinbackend.service.OrganizationService;
+import ppl.momofin.momofinbackend.service.UserService;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/organizations")
 public class OrganizationController {
-
     private final OrganizationService organizationService;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public OrganizationController(OrganizationService organizationService) {
+    public OrganizationController(OrganizationService organizationService,
+                                  UserService userService,
+                                  JwtUtil jwtUtil) {
         this.organizationService = organizationService;
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
     }
 
     @GetMapping("/{orgId}")
@@ -38,15 +54,10 @@ public class OrganizationController {
         return ResponseEntity.ok(users);
     }
 
-    @DeleteMapping("/{orgId}/users/{userId}")
-    public ResponseEntity<Void> removeUserFromOrganization(@PathVariable Long orgId, @PathVariable Long userId) {
-        organizationService.removeUserFromOrganization(orgId, userId);
-        return ResponseEntity.noContent().build();
-    }
-
     @PutMapping("/{orgId}/users/{userId}")
     public ResponseEntity<UserDTO> updateUserInOrganization(@PathVariable Long orgId, @PathVariable Long userId, @RequestBody UserDTO userDTO) {
         UserDTO updatedUser = organizationService.updateUserInOrganization(orgId, userId, userDTO);
         return ResponseEntity.ok(updatedUser);
     }
+
 }

--- a/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
+++ b/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import ppl.momofin.momofinbackend.dto.UserDTO;
 import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;

--- a/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
+++ b/src/main/java/ppl/momofin/momofinbackend/controller/OrganizationController.java
@@ -59,5 +59,32 @@ public class OrganizationController {
         UserDTO updatedUser = organizationService.updateUserInOrganization(orgId, userId, userDTO);
         return ResponseEntity.ok(updatedUser);
     }
+    @DeleteMapping("/{orgId}/users/{userId}")
+    public ResponseEntity<Response> deleteUser(
+            @PathVariable Long orgId,
+            @PathVariable Long userId,
+            @RequestHeader("Authorization") String token) {
+        try {
+            String username = getUsername(token);
+            User requestingUser = userService.fetchUserByUsername(username);
+
+            organizationService.deleteUser(orgId, userId, requestingUser);
+            return ResponseEntity.noContent().build();
+        } catch (UserDeletionException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new ErrorResponse(e.getMessage()));
+        } catch (OrganizationNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new ErrorResponse(e.getMessage()));
+        }
+    }
+
+    private String getUsername(String token) {
+        // Remove "Bearer " prefix and then use correct method name
+        token = token.substring(7);
+        return jwtUtil.extractUsername(token);
+    }
 
 }

--- a/src/main/java/ppl/momofin/momofinbackend/error/UserDeletionException.java
+++ b/src/main/java/ppl/momofin/momofinbackend/error/UserDeletionException.java
@@ -1,0 +1,7 @@
+package ppl.momofin.momofinbackend.error;
+
+public class UserDeletionException extends RuntimeException {
+    public UserDeletionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
@@ -89,11 +89,8 @@ public class OrganizationService {
     }
     @Transactional
     public void deleteUser(Long orgId, Long userId, User requestingUser) {
-        System.out.println("Starting delete user process...");
         Organization org = findOrganizationById(orgId);
-        System.out.println("Found organization: " + org.getName());
         User userToDelete = findUserById(userId);
-        System.out.println("Found user to delete: " + userToDelete.getUsername());
         // Don't allow deletion of the system deleted user
         if (userId == -1) {
             throw new UserDeletionException("Cannot delete system user");

--- a/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ppl.momofin.momofinbackend.dto.UserDTO;
 import ppl.momofin.momofinbackend.error.InvalidOrganizationException;
 import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;
+import ppl.momofin.momofinbackend.error.UserDeletionException;
 import ppl.momofin.momofinbackend.model.Organization;
 import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.repository.OrganizationRepository;
@@ -51,15 +52,6 @@ public class OrganizationService {
                 .toList();
     }
 
-    public void removeUserFromOrganization(Long orgId, Long userId) {
-        Organization org = findOrganizationById(orgId);
-        User user = findUserById(userId);
-        if (!user.getOrganization().equals(org)) {
-            throw new IllegalArgumentException("User does not belong to this organization");
-        }
-        userRepository.delete(user);
-    }
-
     public UserDTO updateUserInOrganization(Long orgId, Long userId, UserDTO updatedUserDTO) {
         Organization org = findOrganizationById(orgId);
         User user = findUserById(userId);
@@ -95,4 +87,5 @@ public class OrganizationService {
         Organization newOrganization = new Organization(name, description, industry, location);
         return organizationRepository.save(newOrganization);
     }
+
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/UserServiceImpl.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/UserServiceImpl.java
@@ -80,7 +80,6 @@ public class UserServiceImpl implements UserService{
 
         updatePasswordIfRequired(existingUser, oldPassword, newPassword);
         updateUserFields(existingUser, updatedUser);
-        logger.info("Old Password: {}, new Password: {}", oldPassword, newPassword);
         User savedUser = userRepository.save(existingUser);
         logger.info("User with ID: {} successfully updated and saved", userId);
 

--- a/src/main/java/ppl/momofin/momofinbackend/service/UserServiceImpl.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/UserServiceImpl.java
@@ -80,7 +80,7 @@ public class UserServiceImpl implements UserService{
 
         updatePasswordIfRequired(existingUser, oldPassword, newPassword);
         updateUserFields(existingUser, updatedUser);
-
+        logger.info("Old Password: {}, new Password: {}", oldPassword, newPassword);
         User savedUser = userRepository.save(existingUser);
         logger.info("User with ID: {} successfully updated and saved", userId);
 

--- a/src/test/java/ppl/momofin/momofinbackend/controller/OrganizationControllerTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/controller/OrganizationControllerTest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 

--- a/src/test/java/ppl/momofin/momofinbackend/controller/OrganizationControllerTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/controller/OrganizationControllerTest.java
@@ -9,21 +9,31 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import ppl.momofin.momofinbackend.dto.UserDTO;
+import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;
+import ppl.momofin.momofinbackend.error.UserDeletionException;
 import ppl.momofin.momofinbackend.model.Organization;
 import ppl.momofin.momofinbackend.model.User;
+import ppl.momofin.momofinbackend.security.JwtUtil;
 import ppl.momofin.momofinbackend.service.OrganizationService;
+import ppl.momofin.momofinbackend.service.UserService;
 
 import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 
 class OrganizationControllerTest {
 
     private MockMvc mockMvc;
+    @Mock
+    private UserService userService;  // Add this
+
+    @Mock
+    private JwtUtil jwtUtil;
 
     @Mock
     private OrganizationService organizationService;
@@ -38,12 +48,17 @@ class OrganizationControllerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockMvc = MockMvcBuilders.standaloneSetup(organizationController).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(organizationController)
+                .setControllerAdvice() // Add any exception handlers if you have them
+                .build();
 
         testOrg = new Organization("Test Org", "Test Description");
         testOrg.setOrganizationId(1L);
-        testUser = new User(testOrg, "testuser", "Test User", "test@example.com", "password", "Developer", false);
-        testUserDTO = new UserDTO(testUser.getUserId(), testUser.getUsername(), testUser.getName(), testUser.getEmail(), testUser.getPosition(), testUser.isOrganizationAdmin());
+        testUser = new User(testOrg, "testuser", "Test User", "test@example.com",
+                "password", "Developer", false);
+        testUserDTO = new UserDTO(testUser.getUserId(), testUser.getUsername(),
+                testUser.getName(), testUser.getEmail(), testUser.getPosition(),
+                testUser.isOrganizationAdmin(), testUser.isMomofinAdmin());
     }
 
     @Test
@@ -69,7 +84,16 @@ class OrganizationControllerTest {
 
     @Test
     void removeUserFromOrganization_ShouldReturnNoContent() throws Exception {
-        mockMvc.perform(delete("/api/organizations/1/users/1"))
+        String token = "Bearer valid_token";
+        User adminUser = new User();
+        adminUser.setUsername("admin");
+        adminUser.setOrganizationAdmin(true);
+
+        when(jwtUtil.extractUsername(anyString())).thenReturn("admin");
+        when(userService.fetchUserByUsername("admin")).thenReturn(adminUser);
+
+        mockMvc.perform(delete("/api/organizations/1/users/1")
+                        .header("Authorization", token))
                 .andExpect(status().isNoContent());
     }
 
@@ -95,4 +119,53 @@ class OrganizationControllerTest {
 
         verify(organizationService).findOrganizationById(1L);
     }
+    @Test
+    void deleteUser_Success() throws Exception {
+        // Setup
+        String token = "Bearer valid_token";
+        User adminUser = new User();
+        adminUser.setUsername("admin");
+        adminUser.setOrganizationAdmin(true);
+
+        when(jwtUtil.extractUsername(anyString())).thenReturn("admin");
+        when(userService.fetchUserByUsername("admin")).thenReturn(adminUser);
+
+        // Execute & Verify
+        mockMvc.perform(delete("/api/organizations/1/users/23")
+                        .header("Authorization", token))
+                .andExpect(status().isNoContent());
+
+        verify(organizationService).deleteUser(1L, 23L, adminUser);
+    }
+
+    @Test
+    void deleteUser_ReturnsForbidden_WhenNotAuthorized() throws Exception {
+        // Setup
+        String token = "Bearer valid_token";
+        when(jwtUtil.extractUsername(anyString())).thenReturn("user");
+        when(userService.fetchUserByUsername("user")).thenReturn(new User());
+        doThrow(new UserDeletionException("Not authorized"))
+                .when(organizationService).deleteUser(anyLong(), anyLong(), any(User.class));
+
+        // Execute & Verify
+        mockMvc.perform(delete("/api/organizations/1/users/23")
+                        .header("Authorization", token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteUser_ReturnsNotFound_WhenOrganizationNotFound() throws Exception {
+        // Setup
+        String token = "Bearer valid_token";
+        when(jwtUtil.extractUsername(anyString())).thenReturn("admin");
+        when(userService.fetchUserByUsername("admin")).thenReturn(new User());
+        doThrow(new OrganizationNotFoundException("Organization not found"))
+                .when(organizationService).deleteUser(anyLong(), anyLong(), any(User.class));
+
+        // Execute & Verify
+        mockMvc.perform(delete("/api/organizations/1/users/23")
+                        .header("Authorization", token))
+                .andExpect(status().isNotFound());
+    }
+
 }

--- a/src/test/java/ppl/momofin/momofinbackend/dto/UserDTOTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/dto/UserDTOTest.java
@@ -24,7 +24,7 @@ class UserDTOTest {
 
     @Test
     void toUser_ShouldCreateUserCorrectly() {
-        UserDTO userDTO = new UserDTO(1L, "testuser", "Test User", "test@example.com", "Developer", false);
+        UserDTO userDTO = new UserDTO(1L, "testuser", "Test User", "test@example.com", "Developer", false, false);
 
         User user = userDTO.toUser();
 

--- a/src/test/java/ppl/momofin/momofinbackend/service/OrganizationServiceTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/service/OrganizationServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.MockitoAnnotations;
 import ppl.momofin.momofinbackend.dto.UserDTO;
 import ppl.momofin.momofinbackend.error.InvalidOrganizationException;
 import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;
+import ppl.momofin.momofinbackend.error.UserDeletionException;
 import ppl.momofin.momofinbackend.model.Organization;
 import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.repository.OrganizationRepository;
@@ -57,34 +58,13 @@ class OrganizationServiceTest {
     }
 
     @Test
-    void removeUserFromOrganization_ShouldRemoveUserSuccessfully() {
-        when(organizationRepository.findById(1L)).thenReturn(Optional.of(testOrg));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-
-        organizationService.removeUserFromOrganization(1L, 1L);
-
-        verify(userRepository).delete(testUser);
-    }
-
-    @Test
-    void removeUserFromOrganization_ShouldThrowException_WhenUserNotInOrganization() {
-        Organization anotherOrg = new Organization("Another Org", "Another Description");
-        anotherOrg.setOrganizationId(2L);
-        User userInAnotherOrg = new User(anotherOrg, "anotheruser", "Another User", "another@example.com", "password", "Developer", false);
-
-        when(organizationRepository.findById(1L)).thenReturn(Optional.of(testOrg));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(userInAnotherOrg));
-
-        assertThrows(IllegalArgumentException.class, () -> organizationService.removeUserFromOrganization(1L, 2L));
-    }
-
-    @Test
     void updateUserInOrganization_ShouldUpdateUserSuccessfully() {
         when(organizationRepository.findById(1L)).thenReturn(Optional.of(testOrg));
         when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
         when(userRepository.save(any(User.class))).thenReturn(testUser);
 
-        UserDTO updatedUserDTO = new UserDTO(null, "updateduser", "Updated User", "updated@example.com", "Senior Developer", false);
+        UserDTO updatedUserDTO = new UserDTO(null, "updateduser", "Updated User",
+                "updated@example.com", "Senior Developer", false, false);  // Added isMomofinAdmin
         UserDTO result = organizationService.updateUserInOrganization(1L, 1L, updatedUserDTO);
 
         assertEquals(updatedUserDTO.getUsername(), result.getUsername());
@@ -97,13 +77,16 @@ class OrganizationServiceTest {
     void updateUserInOrganization_ShouldThrowException_WhenUserNotInOrganization() {
         Organization anotherOrg = new Organization("Another Org", "Another Description");
         anotherOrg.setOrganizationId(2L);
-        User userInAnotherOrg = new User(anotherOrg, "anotheruser", "Another User", "another@example.com", "password", "Developer", false);
+        User userInAnotherOrg = new User(anotherOrg, "anotheruser", "Another User",
+                "another@example.com", "password", "Developer", false);
 
         when(organizationRepository.findById(1L)).thenReturn(Optional.of(testOrg));
         when(userRepository.findById(2L)).thenReturn(Optional.of(userInAnotherOrg));
 
-        UserDTO updatedUserDTO = new UserDTO(null, "updateduser", "Updated User", "updated@example.com", "Senior Developer", false);
-        assertThrows(IllegalArgumentException.class, () -> organizationService.updateUserInOrganization(1L, 2L, updatedUserDTO));
+        UserDTO updatedUserDTO = new UserDTO(null, "updateduser", "Updated User",
+                "updated@example.com", "Senior Developer", false, false);  // Added isMomofinAdmin
+        assertThrows(IllegalArgumentException.class,
+                () -> organizationService.updateUserInOrganization(1L, 2L, updatedUserDTO));
     }
 
     @Test
@@ -111,14 +94,6 @@ class OrganizationServiceTest {
         when(organizationRepository.findById(999L)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> organizationService.getUsersInOrganization(999L));
-    }
-
-    @Test
-    void findUserById_ShouldThrowException_WhenUserNotFound() {
-        when(organizationRepository.findById(1L)).thenReturn(Optional.of(testOrg));
-        when(userRepository.findById(999L)).thenReturn(Optional.empty());
-
-        assertThrows(RuntimeException.class, () -> organizationService.removeUserFromOrganization(1L, 999L));
     }
     @Test
     void updateOrganization_ShouldUpdateAndReturnOrganization() {
@@ -257,4 +232,156 @@ class OrganizationServiceTest {
         assertThrows(OrganizationNotFoundException.class,
                 () -> organizationService.findOrganizationById(1L));
     }
+    @Test
+    void deleteUser_Success() {
+        // Setup
+        Organization org = new Organization("Test Org", "Test Description");
+        org.setOrganizationId(1L);
+
+        User adminUser = new User();
+        adminUser.setOrganization(org);
+        adminUser.setOrganizationAdmin(true);
+        adminUser.setUsername("admin");
+
+        User userToDelete = new User();
+        userToDelete.setUserId(23L);
+        userToDelete.setOrganization(org);
+        userToDelete.setOrganizationAdmin(false);
+        userToDelete.setUsername("user");
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org));
+        when(userRepository.findById(23L)).thenReturn(Optional.of(userToDelete));
+
+        // Execute
+        organizationService.deleteUser(1L, 23L, adminUser);
+
+        // Verify
+        verify(userRepository).delete(userToDelete);
+    }
+
+    @Test
+    void deleteUser_ThrowsException_WhenDeletingSystemUser() {
+        // Setup
+        Organization org = new Organization("Test Org", "Test Description");
+        org.setOrganizationId(1L);
+        User adminUser = new User();
+        adminUser.setOrganization(org);
+        adminUser.setOrganizationAdmin(true);
+
+        User systemUser = new User();
+        systemUser.setUserId(-1L);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org));
+        when(userRepository.findById(-1L)).thenReturn(Optional.of(systemUser));
+
+        // Execute & Verify
+        assertThrows(UserDeletionException.class, () ->
+                organizationService.deleteUser(1L, -1L, adminUser)
+        );
+    }
+
+    @Test
+    void deleteUser_ThrowsException_WhenNotOrganizationAdmin() {
+        // Setup
+        Organization org = new Organization("Test Org", "Test Description");
+        org.setOrganizationId(1L);
+        User regularUser = new User();
+        regularUser.setOrganization(org);
+        regularUser.setOrganizationAdmin(false);
+
+        User userToDelete = new User();
+        userToDelete.setUserId(23L);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org));
+        when(userRepository.findById(23L)).thenReturn(Optional.of(userToDelete));
+
+        // Execute & Verify
+        assertThrows(UserDeletionException.class, () ->
+                organizationService.deleteUser(1L, 23L, regularUser)
+        );
+    }
+
+    @Test
+    void deleteUser_ThrowsException_WhenDifferentOrganization() {
+        // Setup
+        Organization org1 = new Organization("Org 1", "Desc 1");
+        org1.setOrganizationId(1L);
+        Organization org2 = new Organization("Org 2", "Desc 2");
+        org2.setOrganizationId(2L);
+
+        User adminUser = new User();
+        adminUser.setOrganization(org1);
+        adminUser.setOrganizationAdmin(true);
+
+        User userToDelete = new User();
+        userToDelete.setUserId(23L);
+        userToDelete.setOrganization(org2);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org1));
+        when(userRepository.findById(23L)).thenReturn(Optional.of(userToDelete));
+
+        // Execute & Verify
+        assertThrows(UserDeletionException.class, () ->
+                organizationService.deleteUser(1L, 23L, adminUser)
+        );
+    }
+
+    @Test
+    void deleteUser_ThrowsException_WhenDeletingOrgAdmin() {
+        // Setup
+        Organization org = new Organization("Test Org", "Test Description");
+        org.setOrganizationId(1L);
+
+        User adminUser = new User();
+        adminUser.setOrganization(org);
+        adminUser.setOrganizationAdmin(true);
+
+        User anotherAdmin = new User();
+        anotherAdmin.setUserId(23L);
+        anotherAdmin.setOrganization(org);
+        anotherAdmin.setOrganizationAdmin(true);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org));
+        when(userRepository.findById(23L)).thenReturn(Optional.of(anotherAdmin));
+
+        // Execute & Verify
+        assertThrows(UserDeletionException.class, () ->
+                organizationService.deleteUser(1L, 23L, adminUser)
+        );
+    }
+
+    @Test
+    void deleteUser_ThrowsException_WhenOrganizationNotFound() {
+        // Setup
+        User adminUser = new User();
+        adminUser.setOrganizationAdmin(true);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // Execute & Verify
+        assertThrows(OrganizationNotFoundException.class, () ->
+                organizationService.deleteUser(1L, 23L, adminUser)
+        );
+    }
+
+    @Test
+    void deleteUser_ThrowsException_WhenUserNotFound() {
+        // Setup
+        Organization org = new Organization("Test Org", "Test Description");
+        org.setOrganizationId(1L);
+
+        User adminUser = new User();
+        adminUser.setOrganization(org);
+        adminUser.setOrganizationAdmin(true);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org));
+        when(userRepository.findById(23L)).thenReturn(Optional.empty());
+
+        // Execute & Verify
+        assertThrows(RuntimeException.class, () ->
+                organizationService.deleteUser(1L, 23L, adminUser)
+        );
+    }
+
+
 }

--- a/src/test/java/ppl/momofin/momofinbackend/service/OrganizationServiceTest.java
+++ b/src/test/java/ppl/momofin/momofinbackend/service/OrganizationServiceTest.java
@@ -382,6 +382,31 @@ class OrganizationServiceTest {
                 organizationService.deleteUser(1L, 23L, adminUser)
         );
     }
+    @Test
+    void deleteUser_ThrowsException_WhenAdminFromDifferentOrganization() {
+        // Setup
+        Organization org1 = new Organization("Org 1", "Desc 1");
+        org1.setOrganizationId(1L);
+
+        Organization adminOrg = new Organization("Admin Org", "Admin Desc");
+        adminOrg.setOrganizationId(2L);
+
+        User adminUser = new User();
+        adminUser.setOrganization(adminOrg);  // Admin is from a different org
+        adminUser.setOrganizationAdmin(true);
+
+        User userToDelete = new User();
+        userToDelete.setUserId(23L);
+        userToDelete.setOrganization(org1);
+
+        when(organizationRepository.findById(1L)).thenReturn(Optional.of(org1));
+        when(userRepository.findById(23L)).thenReturn(Optional.of(userToDelete));
+
+        // Execute & Verify
+        assertThrows(UserDeletionException.class, () ->
+                organizationService.deleteUser(1L, 23L, adminUser)
+        );
+    }
 
 
 }


### PR DESCRIPTION
Successfully implemented safe deletion feature for organization admins to delete regular users form their own organizations. 
## Key Features & Implementation
- Organization admins can now delete regular users from their own organization
- Preserved documents and audit trails after user deletion using database triggers
- Reference handling via triggers:
  - Documents reference user_id -1 after owner deletion
  - Audit trails reference user_id -1 after user deletion
- Permission checks:
  - Only organization admins can delete users (only org admin for now because momofin admin delete features has not been implemented at this stage)
  - Organization admins can only delete users from their own organization
  - Cannot delete organization admins
  - Cannot delete system user (user_id -1)
  - Cannot delete users from other organizations