### PR TITLE
Feature/momofin admin two feature branch merge to dev

### DIFF
--- a/src/main/java/ppl/momofin/momofinbackend/controller/MomofinAdminController.java
+++ b/src/main/java/ppl/momofin/momofinbackend/controller/MomofinAdminController.java
@@ -2,9 +2,12 @@ package ppl.momofin.momofinbackend.controller;
 
 import io.sentry.Sentry;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import ppl.momofin.momofinbackend.dto.UserDTO;
 import ppl.momofin.momofinbackend.error.InvalidOrganizationException;
 import ppl.momofin.momofinbackend.error.OrganizationNotFoundException;
 import ppl.momofin.momofinbackend.error.SecurityValidationException;
@@ -12,11 +15,13 @@ import ppl.momofin.momofinbackend.error.UserAlreadyExistsException;
 import ppl.momofin.momofinbackend.model.Organization;
 import ppl.momofin.momofinbackend.model.User;
 import ppl.momofin.momofinbackend.repository.OrganizationRepository;
+import ppl.momofin.momofinbackend.response.ErrorResponse;
 import ppl.momofin.momofinbackend.response.FetchAllUserResponse;
 import ppl.momofin.momofinbackend.service.OrganizationService;
 import ppl.momofin.momofinbackend.response.OrganizationResponse;
 import ppl.momofin.momofinbackend.service.UserService;
 import ppl.momofin.momofinbackend.request.AddOrganizationRequest;
+import ppl.momofin.momofinbackend.response.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.List;
@@ -152,6 +157,66 @@ public class MomofinAdminController {
             // Handle unexpected errors with 500
             Sentry.captureException(e);
             return ResponseEntity.internalServerError().body(new OrganizationResponse(null, "An unexpected error occurred", null));
+        }
+    }
+    @DeleteMapping("/organizations/{orgId}")
+    public ResponseEntity<OrganizationResponse> deleteOrganization(@PathVariable String orgId) {
+        try {
+            organizationService.deleteOrganization(UUID.fromString(orgId));
+
+            // Success logging
+            Sentry.captureMessage(String.format(
+                    "[Success] Organization deleted - ID: %s",
+                    orgId
+            ));
+
+            return ResponseEntity.noContent().build();
+        } catch (OrganizationNotFoundException e) {
+            Sentry.captureException(e);
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            logger.error("Unexpected error deleting organization", e);
+            Sentry.captureException(e);
+            return ResponseEntity.status(HttpStatus.GONE)
+                    .body(new OrganizationResponse(null, "Error deleting organization: " + e.getMessage(), null));
+        }
+    }
+    @PutMapping("/organizations/{orgId}/users/{userId}/set-admin")
+    public ResponseEntity<Response> setOrganizationAdmin(
+            @PathVariable String orgId,
+            @PathVariable String userId) {
+        try {
+            organizationService.setOrganizationAdmin(
+                    UUID.fromString(orgId),
+                    UUID.fromString(userId)
+            );
+
+            // Success logging
+            Sentry.captureMessage(String.format(
+                    "[Success] User set as organization admin - UserID: %s, OrgID: %s",
+                    userId,
+                    orgId
+            ));
+
+            return ResponseEntity.noContent().build();
+        } catch (OrganizationNotFoundException e) {
+            // Handle not found with 404
+            Sentry.captureException(e);
+            return ResponseEntity.notFound().build();
+        } catch (SecurityException e) {
+            // Handle security/validation errors
+            logger.error("Security validation error: {}", e.getMessage());
+            Sentry.captureException(e);
+            return ResponseEntity.status(HttpStatus.GONE)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new ErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            // Handle unexpected errors
+            logger.error("Unexpected error setting organization admin", e);
+            Sentry.captureException(e);
+            return ResponseEntity.status(HttpStatus.GONE)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new ErrorResponse("Error setting organization admin: " + e.getMessage()));
         }
     }
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/OrganizationService.java
@@ -15,4 +15,6 @@ public interface OrganizationService {
     List<Organization> getAllOrganizations();
     Organization createOrganization(String name, String description, String industry, String location);
     void deleteUser(UUID orgId, UUID userId, User requestingUser);
+    void deleteOrganization(UUID orgId);
+    User setOrganizationAdmin(UUID orgId, UUID userId);
 }

--- a/src/main/java/ppl/momofin/momofinbackend/service/OrganizationServiceImpl.java
+++ b/src/main/java/ppl/momofin/momofinbackend/service/OrganizationServiceImpl.java
@@ -169,5 +169,29 @@ public class OrganizationServiceImpl implements OrganizationService {
     @Transactional
     public User setOrganizationAdmin(UUID orgId, UUID userId) {
         Organization org = findOrganizationById(orgId);
+        User user = findUserById(userId);
 
+        // Check if user already is an org admin
+        if (user.isOrganizationAdmin()) {
+            throw new UserDeletionException("User is already an organization admin");
+        }
+        // Check if user belongs to the organization
+        if (!user.getOrganization().equals(org)) {
+            throw new SecurityException("User does not belong to this organization");
+        }
+
+        // Check if user is momofin admin (can't be both)
+        if (user.isMomofinAdmin()) {
+            throw new SecurityException("Momofin admins cannot be set as organization admins directly");
+        }
+
+        // Check if trying to modify deleted user
+        if (user.getUsername().equals("deleted_user")) {
+            throw new SecurityException("Cannot modify system user");
+        }
+
+        // Set user as organization admin
+        user.setOrganizationAdmin(true);
+        return userRepository.save(user);
+    }
 }


### PR DESCRIPTION
Merge Momofin Admin Features

This merge request implements the Momofin admin features for user deletion, organization deletion, and set organization admin.

Changes:
- Implement user deletion for Momofin admin from view all users page
- Implement organization deletion with proper handling of Momofin admin users
- Add set organization admin feature
- Add proper error handling and validation checks
- Add comprehensive test coverage

Implementation Notes:
- User deletion leverages existing safe deletion mechanism with DB triggers
- Organization deletion preserves Momofin admin accounts by removing org reference
- Set organization admin includes validation for existing org admins and Momofin admins
- All features properly handle system's deleted user reference
- Consistent error handling using GONE status
- Sentry logging for monitoring success and errors

Security Considerations:
- All endpoints restricted to Momofin admin access
- Proper validation of user-organization relationships
- Protection against modifying system users
- Momofin admins cannot delete other Momofin admins